### PR TITLE
Fix iOS Plugin Methods

### DIFF
--- a/ios/Plugin/ZeroConfPlugin.m
+++ b/ios/Plugin/ZeroConfPlugin.m
@@ -4,5 +4,11 @@
 // Define the plugin using the CAP_PLUGIN Macro, and
 // each method the plugin supports using the CAP_PLUGIN_METHOD macro.
 CAP_PLUGIN(ZeroConfPlugin, "ZeroConf",
-           CAP_PLUGIN_METHOD(echo, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(getHostname, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(register, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(unregister, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(stop, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(watch, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(unwatch, CAPPluginReturnPromise);
 )
+


### PR DESCRIPTION
The iOS implementation is currently not working. Every plugin call results in an "Error: not implemented on ios".
This fixes that by declaring the iOS plugin methods, which were missing.