### PR TITLE
Fixed iOS callback function bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.2.0] - 2022-11-25
+- Fixed a bug in the iOS version when calling watch(), the callback function would not be executed when new services were discovered
+
 ## [1.0.0] - 2021-11-02
 
 - First version: rewrote the original Cordova plugin as Capacitor plugin and added support for Electron plaform

--- a/ios/Plugin/ZeroConfPlugin.m
+++ b/ios/Plugin/ZeroConfPlugin.m
@@ -8,7 +8,7 @@ CAP_PLUGIN(ZeroConfPlugin, "ZeroConf",
            CAP_PLUGIN_METHOD(register, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(unregister, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(stop, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(watch, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(watch, CAPPluginReturnCallback);
            CAP_PLUGIN_METHOD(unwatch, CAPPluginReturnPromise);
 )
 

--- a/ios/Plugin/ZeroConfPlugin.swift
+++ b/ios/Plugin/ZeroConfPlugin.swift
@@ -88,6 +88,7 @@ public class ZeroConfPlugin: CAPPlugin {
     }
 
     @objc func watch(_ call: CAPPluginCall) {
+        call.keepAlive = true
         let typeParam = call.getString("type")
         let domainParam = call.getString("domain")
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-zeroconf",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Capacitor ZeroConf plugin",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Updated the iOS plugin to use the correct capacitor function callback type rather than the promise return type.